### PR TITLE
lib/checksum/mod: fix missing space in unsuitable file error

### DIFF
--- a/delsum-lib/src/checksum/mod.rs
+++ b/delsum-lib/src/checksum/mod.rs
@@ -375,7 +375,7 @@ impl std::fmt::Display for CheckReverserError {
             MissingParameter(s) => write!(f, "Missing Parameters: {}", s),
             UnsuitableFiles(s) => write!(
                 f,
-                "Could not reverse because\
+                "Could not reverse because \
                 files are unsuitable: {}",
                 s
             ),


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@riseup.net>