### PR TITLE
Add Windows Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,53 +4,30 @@ permissions:
   id-token: write
   contents: read
   attestations: write
+  packages: write
 jobs:
-  #  build_windows:
-  #    name: Build Windows Binary
-  #    runs-on: windows-latest
-  #    steps:
-  #      - uses: actions/checkout@v2    
-  #      - uses: actions-rs/toolchain@v1
-  #        with:
-  #          toolchain: stable
-  #          target: x86_64-pc-windows-gnu
-  #          default: true
-  #      - run: which cargo
-  #      - uses: msys2/setup-msys2@v2
-  #        with:
-  #          install: gcc make wget lzip m4
-  #      - name: Cache dependencies
-  #        id: cache-deps
-  #        uses: actions/cache@v2
-  #        with:
-  #          path: output
-  #          key: "${{ runner.os }}-deps"
-  #      - name: Build dependencies
-  #        if: steps.cache-deps.outputs.cache-hit != 'true'
-  #        shell: msys2 {0}
-  #        run: |
-  #          cd "$GITHUB_WORKSPACE"
-  #          bash build.sh
-  #      - uses: actions/cache@v2
-  #        with:
-  #          path: |
-  #            ~/.cargo/registry
-  #            ~/.cargo/git
-  #            target
-  #          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-  #      - shell: msys2 {0}
-  #        run: |
-  #          export PATH="/c/Rust/.cargo/bin/:$PATH"
-  #          export DELSUM_STATIC_LIBS=1
-  #          export DELSUM_NTL_LIB_PATH="$GITHUB_WORKSPACE\output\lib"
-  #          export DELSUM_NTL_INCLUDE="$GITHUB_WORKSPACE\output\include"
-  #          cargo build --release --target x86_64-pc-windows-gnu
-  #          cargo install cargo-strip
-  #          cargo strip --target x86_64-pc-windows-gnu
-  #      - uses: actions/upload-artifact@v2
-  #        with:
-  #          name: delsum_win
-  #          path: 'target\x86_64-pc-windows-gnu\release\delsum.exe'
+  build_windows:
+    name: Build and Tag MXE Build Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log into Container registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build or Pull MXE Docker image
+        run: |
+          COMMIT_SHA=$(sha1sum ./Dockerfile.mxe | cut -c1-7)
+          IMAGE_NAME=ghcr.io/${{ github.repository }}-mxe-build:$COMMIT_SHA
+          docker pull $IMAGE_NAME || (docker build -t $IMAGE_NAME -f Dockerfile.mxe . && docker push $IMAGE_NAME)
+      - name: Run Build in Docker image
+        run: |
+          COMMIT_SHA=$(sha1sum ./Dockerfile.mxe | cut -c1-7)
+          IMAGE_NAME=ghcr.io/${{ github.repository }}-mxe-build:$COMMIT_SHA
+          docker run -v $PWD:/src -w /src $IMAGE_NAME ./build_mxe.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: delsum_win
+          path: 'target/x86_64-pc-windows-gnu/dist/delsum.exe'
   build_linux:
     name: Build Linux Binary
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ permissions:
   attestations: write
 jobs:
   build_windows:
-    name: Build and Tag MXE Build Docker
+    name: Build Windows Binary
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,11 @@ jobs:
           COMMIT_SHA=$(sha1sum ./Dockerfile.mxe | cut -c1-7)
           IMAGE_NAME=$(echo ghcr.io/${{ github.repository }}-mxe-build:$COMMIT_SHA | tr '[:upper:]' '[:lower:]')
           docker run -v $PWD:/src -w /src $IMAGE_NAME ./build_mxe.sh
+      - name: Generate artifact attestation
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'target/x86_64-pc-windows-gnu/dist/delsum.exe'
       - uses: actions/upload-artifact@v4
         with:
           name: delsum_win

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ permissions:
   id-token: write
   contents: read
   attestations: write
-  packages: write
 jobs:
   build_windows:
     name: Build and Tag MXE Build Docker
@@ -19,7 +18,7 @@ jobs:
           COMMIT_SHA=$(sha1sum ./Dockerfile.mxe | cut -c1-7)
           IMAGE_NAME=$(echo ghcr.io/${{ github.repository }}-mxe-build:$COMMIT_SHA | tr '[:upper:]' '[:lower:]')
 
-          docker pull $IMAGE_NAME || (docker build -t $IMAGE_NAME -f Dockerfile.mxe . && docker push $IMAGE_NAME)
+          docker pull $IMAGE_NAME || (docker build -t $IMAGE_NAME -f Dockerfile.mxe .)
       - name: Run Build in Docker image
         run: |
           COMMIT_SHA=$(sha1sum ./Dockerfile.mxe | cut -c1-7)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,12 +17,13 @@ jobs:
       - name: Build or Pull MXE Docker image
         run: |
           COMMIT_SHA=$(sha1sum ./Dockerfile.mxe | cut -c1-7)
-          IMAGE_NAME=ghcr.io/${{ github.repository }}-mxe-build:$COMMIT_SHA
+          IMAGE_NAME=$(echo ghcr.io/${{ github.repository }}-mxe-build:$COMMIT_SHA | tr '[:upper:]' '[:lower:]')
+
           docker pull $IMAGE_NAME || (docker build -t $IMAGE_NAME -f Dockerfile.mxe . && docker push $IMAGE_NAME)
       - name: Run Build in Docker image
         run: |
           COMMIT_SHA=$(sha1sum ./Dockerfile.mxe | cut -c1-7)
-          IMAGE_NAME=ghcr.io/${{ github.repository }}-mxe-build:$COMMIT_SHA
+          IMAGE_NAME=$(echo ghcr.io/${{ github.repository }}-mxe-build:$COMMIT_SHA | tr '[:upper:]' '[:lower:]')
           docker run -v $PWD:/src -w /src $IMAGE_NAME ./build_mxe.sh
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,22 @@
+name: Check MXE Docker Cache
+on: [push]
+branches: [main]
+permissions:
+  id-token: write
+  contents: read
+  packages: write
+jobs:
+  build_docker:
+    name: Build and Tag MXE Build Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log into Container registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build or Pull MXE Docker image
+        run: |
+          COMMIT_SHA=$(sha1sum ./Dockerfile.mxe | cut -c1-7)
+          IMAGE_NAME=$(echo ghcr.io/${{ github.repository }}-mxe-build:$COMMIT_SHA | tr '[:upper:]' '[:lower:]')
+
+          docker pull $IMAGE_NAME || (docker build -t $IMAGE_NAME -f Dockerfile.mxe . && docker push $IMAGE_NAME)

--- a/Dockerfile.mxe
+++ b/Dockerfile.mxe
@@ -1,0 +1,26 @@
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+ENV MXE_VERSION=f7068741
+ENV GF2X_VERSION=1c4974a4
+RUN apt update \
+ && apt install -y build-essential wget git autoconf automake autopoint bison \
+                   flex gperf libtool lzip ruby unzip 7zip libtool \
+                   python3-mako intltool libgtk2.0-dev libtool-bin \
+                   python-is-python3 texinfo git curl rustup
+WORKDIR /opt
+RUN git clone https://github.com/mxe/mxe.git mxe
+WORKDIR /opt/mxe
+RUN git checkout $MXE_VERSION
+ENV PATH=$PATH:/opt/mxe/usr/bin
+RUN make MXE_TARGETS=x86_64-w64-mingw32.shared -j$(nproc) cc
+# HACK: rust has a forced link command that uses the wrong name
+RUN ln -s libpthread.dll.a usr/x86_64-w64-mingw32.shared/lib/libpthread.a
+WORKDIR /opt
+RUN git clone https://gitlab.inria.fr/gf2x/gf2x gf2x
+WORKDIR /opt/gf2x
+RUN git checkout $GF2X_VERSION
+RUN autoreconf --install
+ENV CFLAGS="-march=westmere"
+RUN ./configure --host=x86_64-w64-mingw32.shared --enable-static --disable-shared --prefix=/opt/mxe/usr
+RUN make -j$(nproc) && make install
+WORKDIR /opt

--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ Some (incomplete) explanation of the algorithms used is found [here](algorithms.
 Installing
 ----------
 There is a linux build which has the gf2x library compiled in [here](https://github.com/8051Enthusiast/delsum/releases), but keep in mind that it is compiled without most modern x86 extensions and therefore can't take advantage of some optimized routines in `gf2x` which makes CRC reversing a lot faster.
-I'm also too dumb for doing a Windows build, so sorry for that.
 
 This program links against the [`gf2x`](https://gitlab.inria.fr/gf2x/gf2x) library.
 
@@ -214,6 +213,8 @@ cargo install delsum
 ```
 
 If you want to link the gf2x library statically, you can set the environment variable `GF2POLY_STATIC_LIB=1` when running `cargo`.
+
+At present, building on Windows is unsupported. However, it is possible to cross-compile using [the MXE cross build environment](https://mxe.cc/). There is an [included Dockerfile](./Dockerfile.mxe) designed to make this much easier. (It is hoped, but not verifed, that this will also work with Docker Desktop on Windows.)
 
 Acknowledgements
 ----------------

--- a/build_mxe.sh
+++ b/build_mxe.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# buildscript for the ci in order to build the
-# static libraries
+# buildscript for the ci in order to build the Windows version in the MXE container
 set -eu -o pipefail
 [ $(id -u) -eq 0 ] && (useradd -u $(stat -c %u README.md) -m build && su -c "$0" build)
 [ $(id -u) -eq 0 ] && exit 0

--- a/build_mxe.sh
+++ b/build_mxe.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# buildscript for the ci in order to build the
+# static libraries
+set -eu -o pipefail
+[ $(id -u) -eq 0 ] && (useradd -u $(stat -c %u README.md) -m build && su -c "$0" build)
+[ $(id -u) -eq 0 ] && exit 0
+export GF2POLY_STATIC_LIB=1
+export GF2POLY_LIBRARY_PATH=/opt/mxe/usr/lib
+export PATH=$PATH:$HOME/.cargo/bin:/opt/mxe/usr/bin
+rustup install stable
+rustup target add x86_64-pc-windows-gnu
+cargo fetch
+mkdir -p .cargo
+echo -e "[target.x86_64-pc-windows-gnu]\nrustflags = \"-Cdlltool=x86_64-w64-mingw32.shared-dlltool -Cdefault-linker-libraries=yes -Ctarget-cpu=westmere -Clto=false\"\nlinker = \"x86_64-w64-mingw32.shared-gcc\"" >.cargo/config.toml
+sed -i -e '/lto = true/d' Cargo.toml
+cargo build --target x86_64-pc-windows-gnu --profile=dist


### PR DESCRIPTION
A path for building on Windows has been added.

Rather than a native build, it is a cross-compile with MXE done in a Docker container, which facilitates several hacks that were needed to get it working. It is hoped (but not tested) this will work with Docker Desktop on Windows for those who need a native build.

The initial container build will take over 30 minutes, but once built, it will push to GitHub Packages. This will allow the container to be re-used, resulting in a typical build time of less than 3 minutes. Once this is built, I would recommend going to your GitHub profile -> Packages and then marking the container as private visibility, just to avoid confusion among your users.

Hopefully this is a good approach. Let me know if you have any questions!